### PR TITLE
Update asterisk_meetmeusers - issue4888

### DIFF
--- a/plugins/asterisk_meetmeusers
+++ b/plugins/asterisk_meetmeusers
@@ -87,12 +87,10 @@ my $nb = 0;
 
 #* Total number of MeetMe users: 1
 
-while (($line = $pop->getline) and ($line !~ /END COMMAND|No active MeetMe/o))
-{
-    $nb = $1 if $line =~ /MeetMe users:\s(\d)$/;
-}
 while (($line = $pop->getline) and ($line !~ /END COMMAND/o))
-{}
+{
+    $nb = $1 if $line =~ /MeetMe users:\s(\d+)$/;
+}
 
 
 $pop->print("Action: logoff");


### PR DESCRIPTION
- Modify the REGEXP to be valid when there are more than 9 users
- Remove the second while and the 'No active MeetMe' part of the first while REGEXP : otherwise the script hangs when there are some users


http://projects.xivo.io/issues/4888
